### PR TITLE
Rewrite Back_Compat with hook annotations

### DIFF
--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -10,59 +10,79 @@
  * @since 0.1.0
  */
 
-/**
- * Prevent switching to Alpha on old versions of WordPress.
- *
- * Switches to the default theme.
- *
- * @since 0.1.0
- */
-function pine_alpha_switch_theme() {
-	switch_theme( WP_DEFAULT_THEME );
-	unset( $_GET['activated'] );
-	add_action( 'admin_notices', 'pine_alpha_upgrade_notice' );
-}
-add_action( 'after_switch_theme', 'pine_alpha_switch_theme' );
+namespace Conedevelopment\WordPress\Alpha;
 
-/**
- * Adds a message for unsuccessful theme switch.
- *
- * Prints an update nag after an unsuccessful attempt to switch to
- * Alpha on WordPress versions prior to 4.7.
- *
- * @since 0.1.0
- *
- * @global string $wp_version WordPress version.
- */
-function pine_alpha_upgrade_notice() {
-	$message = sprintf( __( 'Alpha requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'pine-alpha' ), $GLOBALS['wp_version'] );
-	printf( '<div class="error"><p>%s</p></div>', $message );
-}
+use SzepeViktor\SentencePress\HookAnnotation;
 
-/**
- * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
- *
- * @since 0.1.0
- *
- * @global string $wp_version WordPress version.
- */
-function pine_alpha_customize() {
-	wp_die( sprintf( __( 'Alpha requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'pine-alpha' ), $GLOBALS['wp_version'] ), '', array(
-		'back_link' => true,
-	) );
-}
-add_action( 'load-customize.php', 'pine_alpha_customize' );
+class Back_Compat {
 
-/**
- * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
- *
- * @since 0.1.0
- *
- * @global string $wp_version WordPress version.
- */
-function pine_alpha_preview() {
-	if ( isset( $_GET['preview'] ) ) {
-		wp_die( sprintf( __( 'Alpha requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'pine-alpha' ), $GLOBALS['wp_version'] ) );
+	protected $message;
+
+	/**
+	 * @global string $wp_version WordPress core version.
+	 */
+	public function __construct() {
+		$this->message = sprintf(
+			__( 'Alpha requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'pine-alpha' ),
+			$GLOBALS['wp_version']
+		);
+
+		$this->hookMethods();
 	}
+		
+	/**
+	 * Prevent switching to Alpha on old versions of WordPress.
+	 *
+	 * Switches to the default theme.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @hook after_switch_theme
+	 */
+	public function switch_theme() {
+		switch_theme( WP_DEFAULT_THEME );
+		unset( $_GET['activated'] );
+		add_action( 'admin_notices', array( $this, 'upgrade_notice' ) );
+	}
+
+	/**
+	 * Adds a message for unsuccessful theme switch.
+	 *
+	 * Prints an update nag after an unsuccessful attempt to switch to
+	 * Alpha on WordPress versions prior to 4.7.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @hook skip
+	 */
+	public function upgrade_notice() {
+		printf( '<div class="error"><p>%s</p></div>', esc_html( $this->message ) );
+	}
+
+	/**
+	 * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @hook load-customize.php
+	 */
+	public function pine_alpha_customize() {
+		wp_die( esc_html( $this->message ), '', array(
+			'back_link' => true,
+		) );
+	}
+
+	/**
+	 * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @hook template_redirect
+	 */
+	public function preview() {
+		if ( isset( $_GET['preview'] ) ) {
+			wp_die( esc_html( $this->message ) );
+		}
+	}
+
 }
-add_action( 'template_redirect', 'pine_alpha_preview' );


### PR DESCRIPTION
- egy ilyen class-nak kinéző izébe lett összelapátolva
- kapott namespace-t 🎉 
- 1 property-be ment a 3 üzenet
- `add_action`-ök helyett `@hook after_switch_theme` lett a docblock-ban, amit [a class-om](https://github.com/szepeviktor/SentencePress/blob/master/src/HookAnnotation.php) be-hook-ol

Idegen még. De hogyan tetszik?